### PR TITLE
Fr 19 sponsor list view

### DIFF
--- a/app/services/index.tsx
+++ b/app/services/index.tsx
@@ -162,9 +162,15 @@ const ListServiceScreen: React.FC = () => {
         ) : (
           <View style={styles.listContainer}>
             {sponsors.map((item) => (
-              <View key={item.nif} style={[styles.sponsorWrapper, isMobile && styles.sponsorWrapperMobile]}>
+              <View
+                key={item.nif}
+                style={[
+                  styles.sponsorWrapper,
+                  isMobile ? styles.sponsorWrapperMobile : styles.sponsorWrapperDesktop
+                ]}
+              >
                 <AdvertisementSponsor sponsor={item} />
-              </View>
+              </View>           
             ))}
           </View>
         )}
@@ -201,6 +207,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: GlobalStyles.white,
     paddingTop: 10,
+    alignSelf: 'center',
   },
   scrollContainer: {
     flexGrow: 1,
@@ -233,19 +240,27 @@ const styles = StyleSheet.create({
     color: GlobalStyles.blue,
   },
   listContainer: {
-    width: '100%',
-    alignItems: 'center',
-    marginLeft: 37,
+    marginLeft: 120,
+    width: '90%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
     marginBottom: 20,
-  },
+  },  
   sponsorWrapper: {
-    marginLeft: 505,
+    margin: 10,
     width: '100%',
     maxWidth: 750,
     marginHorizontal: 'auto',
     alignSelf: 'center',
     marginBottom: 16,
   },
+  sponsorWrapperDesktop: {
+    width: '48%',
+    maxWidth: '48%',
+    marginBottom: 16,
+  },   
   sponsorWrapperMobile: {
     marginLeft: 0,
     width: '100%',

--- a/app/services/index.tsx
+++ b/app/services/index.tsx
@@ -149,6 +149,10 @@ const ListServiceScreen: React.FC = () => {
         {/* LISTADO DE SPONSORS */}
         {loading ? (
           <ActivityIndicator size="large" color={GlobalStyles.blue} />
+        ) : sponsors.length === 0 ? (
+          <Text style={{ marginTop: 20, marginBottom: 5, fontSize: 18, color: GlobalStyles.blue, textAlign: 'center' }}>
+            No se han encontrado resultados para la búsqueda
+          </Text>
         ) : (
           <View style={styles.listContainer}>
             {sponsors.map((item) => (
@@ -159,25 +163,27 @@ const ListServiceScreen: React.FC = () => {
           </View>
         )}
         {/* PAGINACIÓN */}
-        <View style={[styles.paginationContainer, isMobile && styles.paginationContainerMobile]}>
-          <CustomButton
-            title="Anterior"
-            onPress={() => {
-              if (page > 0) setPage(page - 1);
-            }}
-            color="grey"
-            style={{ opacity: page === 0 || totalPages <= 1 ? 0.5 : 1 }}
-          />
-          <Text style={{ marginHorizontal: 10 }}>{page + 1} / {totalPages}</Text>
-          <CustomButton
-            title="Siguiente"
-            onPress={() => {
-              if (page + 1 < totalPages) setPage(page + 1);
-            }}
-            color="blue"
-            style={{ opacity: page + 1 >= totalPages || totalPages <= 1 ? 0.5 : 1 }}
-          />
-        </View>
+        {!loading && sponsors.length > 0 && (
+          <View style={[styles.paginationContainer, isMobile && styles.paginationContainerMobile]}>
+            <CustomButton
+              title="Anterior"
+              onPress={() => {
+                if (page > 0) setPage(page - 1);
+              }}
+              color="grey"
+              style={{ opacity: page === 0 || totalPages <= 1 ? 0.5 : 1 }}
+            />
+            <Text style={{ marginHorizontal: 10 }}>{page + 1} / {totalPages}</Text>
+            <CustomButton
+              title="Siguiente"
+              onPress={() => {
+                if (page + 1 < totalPages) setPage(page + 1);
+              }}
+              color="blue"
+              style={{ opacity: page + 1 >= totalPages || totalPages <= 1 ? 0.5 : 1 }}
+            />
+          </View>
+        )}
       </ScrollView>
     </ThemedView>
   );

--- a/app/services/index.tsx
+++ b/app/services/index.tsx
@@ -170,7 +170,7 @@ const ListServiceScreen: React.FC = () => {
                 ]}
               >
                 <AdvertisementSponsor sponsor={item} />
-              </View>           
+              </View>            
             ))}
           </View>
         )}
@@ -207,7 +207,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: GlobalStyles.white,
     paddingTop: 10,
-    alignSelf: 'center',
   },
   scrollContainer: {
     flexGrow: 1,
@@ -239,56 +238,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: GlobalStyles.blue,
   },
-  listContainer: {
-    marginLeft: 120,
-    width: '90%',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginBottom: 20,
-  },  
-  sponsorWrapper: {
-    margin: 10,
-    width: '100%',
-    maxWidth: 750,
-    marginHorizontal: 'auto',
-    alignSelf: 'center',
-    marginBottom: 16,
-  },
-  sponsorWrapperDesktop: {
-    width: '48%',
-    maxWidth: '48%',
-    marginBottom: 16,
-  },   
-  sponsorWrapperMobile: {
-    marginLeft: 0,
-    width: '100%',
-    maxWidth: 750,
-    marginHorizontal: 'auto',
-    alignSelf: 'center',
-    marginBottom: 16,
-  },
-  filterContainer: {
-    width: 400,
-    alignItems: 'center',
-    marginBottom: 10,
-  },
-  filterContainerMobile: {
-    width: '100%',
-    paddingHorizontal: 16,
-  },  
-  paginationContainer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 10,
-    marginBottom: 20,
-  },
-  paginationContainerMobile: {
-    flexDirection: 'column',
-    gap: 10,
-  },  
   pickerWrapper: {
     width: '100%',
     backgroundColor: GlobalStyles.lightGrey,
@@ -309,6 +258,48 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     fontSize: 16,
   },  
+  filterContainer: {
+    width: 400,
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  filterContainerMobile: {
+    width: '100%',
+    paddingHorizontal: 16,
+  }, 
+  listContainer: {
+    width: '100%',
+    maxWidth: 1200,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignSelf: 'center',
+    marginBottom: 20,
+  },  
+  sponsorWrapper: {
+    padding: 10,
+  },
+  sponsorWrapperDesktop: {
+    width: '45%',
+    maxWidth: 600,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },  
+  sponsorWrapperMobile: {
+    width: '90%',
+  },  
+  paginationContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 20,
+  },
+  paginationContainerMobile: {
+    flexDirection: 'column',
+    gap: 10,
+  },
 });
 
 export default withAuth(ListServiceScreen, [AUTHORITIES.CUSTOMER, AUTHORITIES.COMPANY]);

--- a/app/services/index.tsx
+++ b/app/services/index.tsx
@@ -162,7 +162,7 @@ const ListServiceScreen: React.FC = () => {
         ) : (
           <View style={styles.listContainer}>
             {sponsors.map((item) => (
-              <View key={item.nif} style={styles.sponsorWrapper}>
+              <View key={item.nif} style={[styles.sponsorWrapper, isMobile && styles.sponsorWrapperMobile]}>
                 <AdvertisementSponsor sponsor={item} />
               </View>
             ))}
@@ -236,8 +236,18 @@ const styles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
     marginLeft: 37,
+    marginBottom: 20,
   },
   sponsorWrapper: {
+    marginLeft: 505,
+    width: '100%',
+    maxWidth: 750,
+    marginHorizontal: 'auto',
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  sponsorWrapperMobile: {
+    marginLeft: 0,
     width: '100%',
     maxWidth: 750,
     marginHorizontal: 'auto',

--- a/app/services/index.tsx
+++ b/app/services/index.tsx
@@ -123,12 +123,18 @@ const ListServiceScreen: React.FC = () => {
           <CustomTextInput
             placeholder="Buscar por ciudad"
             value={city}
-            onChangeText={setCity}
+            onChangeText={(text) => {
+              setCity(text);
+              setPage(0);
+            }}
           />
           <CustomTextInput
             placeholder="Buscar por nombre"
             value={name}
-            onChangeText={setName}
+            onChangeText={(text) => {
+              setName(text);
+              setPage(0);
+            }}
           />
           <View style={styles.pickerWrapper}>
             <Picker

--- a/components/AdvertisementSponsor.tsx
+++ b/components/AdvertisementSponsor.tsx
@@ -111,9 +111,7 @@ const styles = StyleSheet.create({
     color: GlobalStyles.darkGrey,
     marginTop: 3,
     marginBottom: 5,
-    textAlign: 'justify',
-    flexWrap: 'wrap',
-    overflow: 'hidden',
+    textAlign: 'center',
     width: '100%',
   },
 });

--- a/components/AdvertisementSponsor.tsx
+++ b/components/AdvertisementSponsor.tsx
@@ -19,17 +19,24 @@ type SponsorProps = {
 const AdvertisementSponsor: React.FC<SponsorProps> = ({ sponsor }) => {
   const { width } = useWindowDimensions();
   const isMobile = width < 768;
-
+  const formatPhoneNumber = (phone: string) => {
+    return phone.replace(/(\d{3})(\d{3})(\d{3})/, '$1 $2 $3');
+  };
+  
   return (
     <View style={[styles.sponsorCard, isMobile ? styles.mobileLayout : styles.desktopLayout]}>
       <Image testID="sponsor-image" source={{ uri: sponsor.imageUrl }} style={[styles.image, isMobile ? styles.imageMobile : styles.imageDesktop]} />
       <View style={styles.infoContainer}>
         <Text style={styles.sponsorName}>{sponsor.name}</Text>
-        <Text style={styles.sponsorText}>📧 {sponsor.email}</Text>
-        <Text style={styles.sponsorText}>📞 {sponsor.telephone}</Text>
-        <Text style={styles.sponsorText}>📍 {sponsor.address}, {sponsor.city}, {sponsor.zipCode}</Text>
-        <Text style={styles.sponsorText}>🆔 NIF: {sponsor.nif}</Text>
+        <Text style={styles.descriptionTitle}>¿Quiénes somos?</Text>
         <Text style={styles.sponsorDescription}>{sponsor.description}</Text>
+        <Text style={styles.descriptionTitle}>Contacto:</Text>
+        <Text style={styles.sponsorText}>📞 {formatPhoneNumber(sponsor.telephone)}</Text>
+        <Text style={styles.sponsorText}>✉️ {sponsor.email}</Text>
+        <Text style={styles.descriptionTitle}>Dirección:</Text>
+        <Text style={styles.sponsorText}>📍 {sponsor.address}, {sponsor.city}, {sponsor.zipCode}</Text>
+        <Text style={styles.descriptionTitle}>Información adicional:</Text>
+        <Text style={styles.sponsorText}>🆔 NIF: {sponsor.nif}</Text>
       </View>
     </View>
   );
@@ -65,13 +72,13 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   imageDesktop: {
-    width: 150,
-    height: 150,
+    width: 175,
+    height: 210,
     marginRight: 15,
   },
   imageMobile: {
-    width: 120,
-    height: 120,
+    width: 165,
+    height: 130,
     marginBottom: 10,
   },
   infoContainer: {
@@ -79,11 +86,18 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   sponsorName: {
-    fontSize: 18,
+    fontSize: 20,
     fontWeight: 'bold',
     color: GlobalStyles.grey,
     marginBottom: 5,
     textAlign: 'center',
+  },
+  descriptionTitle: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: GlobalStyles.grey,
+    textAlign: 'center',
+    marginTop: 10,
   },
   sponsorText: {
     fontSize: 14,
@@ -94,7 +108,8 @@ const styles = StyleSheet.create({
   sponsorDescription: {
     fontSize: 14,
     color: GlobalStyles.darkGrey,
-    marginTop: 5,
+    marginTop: 3,
+    marginBottom: 5,
     textAlign: 'justify',
     flexWrap: 'wrap',
     overflow: 'hidden',

--- a/components/AdvertisementSponsor.tsx
+++ b/components/AdvertisementSponsor.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 3,
     backgroundColor: GlobalStyles.lightGrey,
-    width: '90%',
+    width: '100%',
     alignSelf: 'stretch',
     minHeight: 200,
     display: 'flex',
@@ -63,7 +63,6 @@ const styles = StyleSheet.create({
   desktopLayout: {
     flexDirection: 'row',
     alignItems: 'center',
-    width: 600,
   },
   mobileLayout: {
     flexDirection: 'column',
@@ -84,6 +83,7 @@ const styles = StyleSheet.create({
   },
   infoContainer: {
     flex: 1,
+    justifyContent: 'center',
     width: '100%',
   },
   sponsorName: {
@@ -115,12 +115,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     overflow: 'hidden',
     width: '100%',
-  },
-  listContainer: {
-    width: '100%',
-    flexDirection: 'column',
-    alignItems: 'center',
-    paddingHorizontal: 16,
   },
 });
 

--- a/components/AdvertisementSponsor.tsx
+++ b/components/AdvertisementSponsor.tsx
@@ -42,6 +42,7 @@ const AdvertisementSponsor: React.FC<SponsorProps> = ({ sponsor }) => {
   );
 };
 
+
 const styles = StyleSheet.create({
   sponsorCard: {
     padding: 15,
@@ -62,7 +63,7 @@ const styles = StyleSheet.create({
   desktopLayout: {
     flexDirection: 'row',
     alignItems: 'center',
-    maxWidth: 600,
+    width: 600,
   },
   mobileLayout: {
     flexDirection: 'column',


### PR DESCRIPTION
To test the functionality, you can use the "develop" backend branch.

Changes introduced at the request of pilot users:
- Displays two companies per row if the screen width allows.
- Improved the ads component (highlighting important information).
- If a filter has no results, pagination is removed and an informative message is added stating that there are no results.
- Whenever you filter, you are sent to the first page of results so that you don't end up on a page that doesn't have sponsors.
- Improved layout on mobile and desktop.